### PR TITLE
Improve func_def!() ergonomics some more, rename to func!()

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -17,9 +17,9 @@ macro_rules! func_def {
     };
 
     (
-        @ndecl $type:expr
+        @odecl $type:expr
     ) => {
-        ArgDecl::Named($type)
+        ArgDecl::Optional($type)
     };
 
     (
@@ -32,11 +32,11 @@ macro_rules! func_def {
     };
 
     (
-        @named $name:ident $type:expr
+        @opt $name:ident $type:expr
     ) => {
         ArgDesc {
             name: stringify!($name),
-            typ: func_def!(@ndecl $type),
+            typ: func_def!(@odecl $type),
         }
     };
 
@@ -76,7 +76,7 @@ macro_rules! func_def {
                 return_type: ValType::$return_type,
                 args: &[
                     $(func_def!(@pos $arg_name $arg_type),)*
-                    $(func_def!(@named $dfl_name $dfl_type),)*
+                    $(func_def!(@opt $dfl_name $dfl_type),)*
                 ],
                 arg_pos,
                 min_args: func_def!(@len $($arg_name)*),

--- a/src/stdlib/dhcp.rs
+++ b/src/stdlib/dhcp.rs
@@ -2,7 +2,7 @@ use ezpkt::Dhcp;
 use pkt::arp::hrd;
 use pkt::dhcp::{dhcp_opt, message, opcode, opt, CLIENT_PORT, MAGIC, SERVER_PORT};
 
-use crate::func_def;
+use crate::func;
 use crate::libapi::{FuncDef, Module};
 use crate::str::Buf;
 use crate::sym::Symbol;
@@ -66,28 +66,28 @@ const OPT: Module = module! {
     }
 };
 
-const HDR: FuncDef = func_def!(
+const HDR: FuncDef = func!(
     /// DHCP header
     resynth fn hdr(
         =>
-        opcode: ValDef::U8(opcode::REQUEST),
-        htype: ValDef::U8(hrd::ETHER),
-        hlen: ValDef::U8(6),
-        hops: ValDef::U8(0),
+        opcode: U8 = opcode::REQUEST,
+        htype: U8 = hrd::ETHER,
+        hlen: U8 = 6,
+        hops: U8 = 0,
 
-        xid: ValDef::U32(0),
+        xid: U32 = 0,
 
-        ciaddr: ValDef::Ip4(Ipv4Addr::new(0, 0, 0, 0)),
-        yiaddr: ValDef::Ip4(Ipv4Addr::new(0, 0, 0, 0)),
-        siaddr: ValDef::Ip4(Ipv4Addr::new(0, 0, 0, 0)),
-        giaddr: ValDef::Ip4(Ipv4Addr::new(0, 0, 0, 0)),
+        ciaddr: Ip4 = Ipv4Addr::new(0, 0, 0, 0),
+        yiaddr: Ip4 = Ipv4Addr::new(0, 0, 0, 0),
+        siaddr: Ip4 = Ipv4Addr::new(0, 0, 0, 0),
+        giaddr: Ip4 = Ipv4Addr::new(0, 0, 0, 0),
 
-        chaddr: ValDef::Type(ValType::Str),
+        chaddr: Type = ValType::Str,
 
-        sname: ValDef::Type(ValType::Str),
-        file: ValDef::Type(ValType::Str),
+        sname: Type = ValType::Str,
+        file: Type = ValType::Str,
 
-        magic: ValDef::U32(MAGIC),
+        magic: U32 = MAGIC,
         =>
         Void
     ) -> Str
@@ -137,7 +137,7 @@ const HDR: FuncDef = func_def!(
     }
 );
 
-const OPTION: FuncDef = func_def!(
+const OPTION: FuncDef = func!(
     /// DHCP Option
     resynth fn option(
         opt: U8,

--- a/src/stdlib/dns.rs
+++ b/src/stdlib/dns.rs
@@ -4,7 +4,7 @@ use pkt::Packet;
 
 use ezpkt::UdpFlow;
 
-use crate::func_def;
+use crate::func;
 use crate::libapi::{FuncDef, Module};
 use crate::str::Buf;
 use crate::sym::Symbol;
@@ -125,11 +125,11 @@ const CLASS: Module = module! {
     }
 };
 
-pub(crate) const DNS_NAME: FuncDef = func_def! (
+pub(crate) const DNS_NAME: FuncDef = func! (
     /// A DNS name encoded with length prefixes
     resynth fn name(
         =>
-        complete: ValDef::Bool(true),
+        complete: Bool = true,
         =>
         Str
     ) -> Str
@@ -162,11 +162,11 @@ pub(crate) const DNS_NAME: FuncDef = func_def! (
     }
 );
 
-const DNS_POINTER: FuncDef = func_def! (
+const DNS_POINTER: FuncDef = func! (
     /// A DNS compression pointer
     resynth fn pointer(
         =>
-        offset: ValDef::U16(0x0c),
+        offset: U16 = 0x0c,
         =>
         Void
     ) -> Str
@@ -179,20 +179,20 @@ const DNS_POINTER: FuncDef = func_def! (
     }
 );
 
-const DNS_FLAGS: FuncDef = func_def!(
+const DNS_FLAGS: FuncDef = func!(
     /// a DNS flags field
     resynth fn flags(
         opcode: U8,
         =>
-        response: ValDef::Bool(false),
-        aa: ValDef::Bool(false),
-        tc: ValDef::Bool(false),
-        rd: ValDef::Bool(false),
-        ra: ValDef::Bool(false),
-        z: ValDef::Bool(false),
-        ad: ValDef::Bool(false),
-        cd: ValDef::Bool(false),
-        rcode: ValDef::U8(rcode::NOERROR),
+        response: Bool = false,
+        aa: Bool = false,
+        tc: Bool = false,
+        rd: Bool = false,
+        ra: Bool = false,
+        z: Bool = false,
+        ad: Bool = false,
+        cd: Bool = false,
+        rcode: U8 = rcode::NOERROR,
         =>
         Void
     ) -> U16
@@ -225,16 +225,16 @@ const DNS_FLAGS: FuncDef = func_def!(
     }
 );
 
-const DNS_HDR: FuncDef = func_def!(
+const DNS_HDR: FuncDef = func!(
     /// A DNS header
     resynth fn hdr(
         id: U16,
         flags: U16,
         =>
-        qdcount: ValDef::U16(0),
-        ancount: ValDef::U16(0),
-        nscount: ValDef::U16(0),
-        arcount: ValDef::U16(0),
+        qdcount: U16 = 0,
+        ancount: U16 = 0,
+        nscount: U16 = 0,
+        arcount: U16 = 0,
         =>
         Void
     ) -> Str
@@ -259,13 +259,13 @@ const DNS_HDR: FuncDef = func_def!(
     }
 );
 
-const DNS_QUESTION: FuncDef = func_def!(
+const DNS_QUESTION: FuncDef = func!(
     /// A DNS question
     resynth fn question(
         qname: Str,
         =>
-        qtype: ValDef::U16(1),
-        qclass: ValDef::U16(1),
+        qtype: U16 = 1,
+        qclass: U16 = 1,
         =>
         Void
     ) -> Str
@@ -284,14 +284,14 @@ const DNS_QUESTION: FuncDef = func_def!(
     }
 );
 
-const DNS_ANSWER: FuncDef = func_def!(
+const DNS_ANSWER: FuncDef = func!(
     /// A DNS answer (RR)
     resynth fn answer(
         aname: Str,
         =>
-        atype: ValDef::U16(1),
-        aclass: ValDef::U16(1),
-        ttl: ValDef::U32(229),
+        atype: U16 = 1,
+        aclass: U16 = 1,
+        ttl: U32 = 229,
         =>
         Str
     ) -> Str
@@ -315,15 +315,15 @@ const DNS_ANSWER: FuncDef = func_def!(
     }
 );
 
-const DNS_HOST: FuncDef = func_def!(
+const DNS_HOST: FuncDef = func!(
     /// Perform a DNS lookup, with response
     resynth fn host(
         client: Ip4,
         qname: Str,
         =>
-        ttl: ValDef::U32(229),
-        ns: ValDef::Ip4(Ipv4Addr::new(1, 1, 1, 1)),
-        raw: ValDef::Bool(false),
+        ttl: U32 = 229,
+        ns: Ip4 = Ipv4Addr::new(1, 1, 1, 1),
+        raw: Bool = false,
         =>
         Ip4
     ) -> PktGen

--- a/src/stdlib/erspan1.rs
+++ b/src/stdlib/erspan1.rs
@@ -2,13 +2,13 @@ use std::rc::Rc;
 
 use pkt::Packet;
 
-use crate::func_def;
+use crate::func;
 use crate::libapi::{Class, ClassDef, FuncDef, Module};
 use crate::sym::Symbol;
 use crate::val::{Val, ValDef};
 use ezpkt::Erspan1Flow;
 
-const ENCAP: FuncDef = func_def!(
+const ENCAP: FuncDef = func!(
     /// Encapsulate a sequence of packets
     resynth fn encap(
         gen: PktGen
@@ -45,13 +45,13 @@ impl Class for Erspan1Flow {
     }
 }
 
-const SESSION: FuncDef = func_def!(
+const SESSION: FuncDef = func!(
     /// Create an ERSPAN session
     resynth fn session(
         cl: Ip4,
         sv: Ip4,
         =>
-        raw: ValDef::Bool(false),
+        raw: Bool = false,
         =>
         Void
     ) -> Obj

--- a/src/stdlib/erspan2.rs
+++ b/src/stdlib/erspan2.rs
@@ -2,18 +2,18 @@ use std::rc::Rc;
 
 use pkt::Packet;
 
-use crate::func_def;
+use crate::func;
 use crate::libapi::{Class, ClassDef, FuncDef, Module};
 use crate::sym::Symbol;
 use crate::val::{Val, ValDef};
 use ezpkt::Erspan2Flow;
 
-const ENCAP: FuncDef = func_def!(
+const ENCAP: FuncDef = func!(
     /// Encapsulate packets in ERSPAN2
     resynth fn encap(
         gen: PktGen
         =>
-        port_index: ValDef::U32(0),
+        port_index: U32 = 0,
         =>
         Void
     ) -> PktGen
@@ -47,13 +47,13 @@ impl Class for Erspan2Flow {
     }
 }
 
-const SESSION: FuncDef = func_def!(
+const SESSION: FuncDef = func!(
     /// Create an erspan2 session
     resynth fn session(
         cl: Ip4,
         sv: Ip4,
         =>
-        raw: ValDef::Bool(false),
+        raw: Bool = false,
         =>
         Void
     ) -> Obj

--- a/src/stdlib/gre.rs
+++ b/src/stdlib/gre.rs
@@ -3,13 +3,13 @@ use std::rc::Rc;
 use pkt::gre::GreFlags;
 use pkt::Packet;
 
-use crate::func_def;
+use crate::func;
 use crate::libapi::{Class, ClassDef, FuncDef, Module};
 use crate::sym::Symbol;
 use crate::val::{Val, ValDef};
 use ezpkt::GreFlow;
 
-const ENCAP: FuncDef = func_def!(
+const ENCAP: FuncDef = func!(
     /// Encapsulate packets in GRETAP
     resynth fn encap(
         gen: PktGen
@@ -46,14 +46,14 @@ impl Class for GreFlow {
     }
 }
 
-const SESSION: FuncDef = func_def!(
+const SESSION: FuncDef = func!(
     /// Create a GRETAP session
     resynth fn session(
         cl: Ip4,
         sv: Ip4,
         ethertype: U16,
         =>
-        raw: ValDef::Bool(false),
+        raw: Bool = false,
         =>
         Void
     ) -> Obj

--- a/src/stdlib/io.rs
+++ b/src/stdlib/io.rs
@@ -4,13 +4,13 @@ use std::io::Read;
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 
-use crate::func_def;
+use crate::func;
 use crate::libapi::{Class, ClassDef, FuncDef, Module};
 use crate::str::Buf;
 use crate::sym::Symbol;
 use crate::val::Val;
 
-const IO_FILE: FuncDef = func_def!(
+const IO_FILE: FuncDef = func!(
     /// Load the contents of a file into a string
     resynth fn file(
         filename: Str,
@@ -69,7 +69,7 @@ where
     }
 }
 
-const BUFIO_READ: FuncDef = func_def!(
+const BUFIO_READ: FuncDef = func!(
     /// Read some bytes out of a buffer
     resynth fn read(
         bytes: U64,
@@ -86,7 +86,7 @@ const BUFIO_READ: FuncDef = func_def!(
     }
 );
 
-const BUFIO_READ_ALL: FuncDef = func_def!(
+const BUFIO_READ_ALL: FuncDef = func!(
     /// Read all remaining bytes out of a buffer
     resynth fn read_all(
         =>
@@ -115,7 +115,7 @@ impl Class for BufIo {
     }
 }
 
-const BUFIO: FuncDef = func_def!(
+const BUFIO: FuncDef = func!(
     /// Create a buffer from a string, from which you can read parts in sequence
     resynth fn bufio(
         =>

--- a/src/stdlib/ipv4/icmp.rs
+++ b/src/stdlib/ipv4/icmp.rs
@@ -1,11 +1,11 @@
-use crate::func_def;
+use crate::func;
 use crate::libapi::{Class, ClassDef, FuncDef, Module};
 use crate::str::Buf;
 use crate::sym::Symbol;
 use crate::val::{Val, ValDef};
 use ezpkt::IcmpFlow;
 
-const ICMP_ECHO: FuncDef = func_def!(
+const ICMP_ECHO: FuncDef = func!(
     /// ICMP Ping
     resynth fn echo(
         payload: Str,
@@ -22,7 +22,7 @@ const ICMP_ECHO: FuncDef = func_def!(
     }
 );
 
-const ICMP_ECHO_REPLY: FuncDef = func_def!(
+const ICMP_ECHO_REPLY: FuncDef = func!(
     /// ICMP Ping reply
     resynth fn echo_reply(
         payload: Str,
@@ -53,13 +53,13 @@ impl Class for IcmpFlow {
     }
 }
 
-const ICMP_FLOW: FuncDef = func_def!(
+const ICMP_FLOW: FuncDef = func!(
     /// Create an ICMP flow
     resynth fn flow(
         cl: Ip4,
         sv: Ip4,
         =>
-        raw: ValDef::Bool(false),
+        raw: Bool = false,
         =>
         Void
     ) -> Obj

--- a/src/stdlib/ipv4/mod.rs
+++ b/src/stdlib/ipv4/mod.rs
@@ -6,7 +6,7 @@ use pkt::Packet;
 
 use ezpkt::IpFrag;
 
-use crate::func_def;
+use crate::func;
 use crate::libapi::{Class, ClassDef, FuncDef, Module};
 use crate::str::Buf;
 use crate::sym::Symbol;
@@ -32,19 +32,19 @@ const PROTO: Module = module! {
 
 const IPV4_DGRAM_OVERHEAD: usize = std::mem::size_of::<eth_hdr>() + std::mem::size_of::<ip_hdr>();
 
-const DGRAM: FuncDef = func_def!(
+const DGRAM: FuncDef = func!(
     /// Create a raw IPv4 header or datagram
     resynth fn datagram(
         src: Ip4,
         dst: Ip4,
         =>
-        id: ValDef::U16(0),
-        evil: ValDef::Bool(false),
-        df: ValDef::Bool(false),
-        mf: ValDef::Bool(false),
-        ttl: ValDef::U8(64),
-        frag_off: ValDef::U16(0),
-        proto: ValDef::U8(proto::UDP),
+        id: U16 = 0,
+        evil: Bool = false,
+        df: Bool = false,
+        mf: Bool = false,
+        ttl: U8 = 64,
+        frag_off: U16 = 0,
+        proto: U8 = proto::UDP,
         =>
         Str
     ) -> Pkt
@@ -93,7 +93,7 @@ const DGRAM: FuncDef = func_def!(
     }
 );
 
-const FRAG_FRAGMENT: FuncDef = func_def!(
+const FRAG_FRAGMENT: FuncDef = func!(
     /// Returns an IPv4 packet fragment
     ///
     /// # Arguments
@@ -118,7 +118,7 @@ const FRAG_FRAGMENT: FuncDef = func_def!(
     }
 );
 
-const FRAG_TAIL: FuncDef = func_def!(
+const FRAG_TAIL: FuncDef = func!(
     /// Returns an IPv4 tail-fragment, ie. with MF (more-fragments) bit set to zero.
     /// This is just a convenience function which omits the len parameter.
     ///
@@ -141,7 +141,7 @@ const FRAG_TAIL: FuncDef = func_def!(
     }
 );
 
-const FRAG_DATAGRAM: FuncDef = func_def!(
+const FRAG_DATAGRAM: FuncDef = func!(
     /// Return the entire datagram without fragmenting it
     resynth fn datagram(
         =>
@@ -172,17 +172,17 @@ impl Class for IpFrag {
     }
 }
 
-const FRAG: FuncDef = func_def!(
+const FRAG: FuncDef = func!(
     /// Create a context for a packet which can be arbitrarily fragmented
     resynth fn frag(
         src: Ip4,
         dst: Ip4,
         =>
-        id: ValDef::U16(0),
-        evil: ValDef::Bool(false),
-        df: ValDef::Bool(false),
-        ttl: ValDef::U8(64),
-        proto: ValDef::U8(proto::UDP),
+        id: U16 = 0,
+        evil: Bool = false,
+        df: Bool = false,
+        ttl: U8 = 64,
+        proto: U8 = proto::UDP,
         =>
         Str
     ) -> Obj

--- a/src/stdlib/ipv4/tcp.rs
+++ b/src/stdlib/ipv4/tcp.rs
@@ -1,4 +1,4 @@
-use crate::func_def;
+use crate::func;
 use crate::libapi::{Class, ClassDef, FuncDef, Module};
 use crate::str::Buf;
 use crate::sym::Symbol;
@@ -7,7 +7,7 @@ use crate::val::{Val, ValDef};
 use ezpkt::TcpFlow;
 use pkt::Packet;
 
-const TCP_OPEN: FuncDef = func_def!(
+const TCP_OPEN: FuncDef = func!(
     /// Performs a TCP 3-way handshake
     resynth fn open(
         =>
@@ -22,14 +22,14 @@ const TCP_OPEN: FuncDef = func_def!(
         }
 );
 
-const TCP_CL_MSG: FuncDef = func_def!(
+const TCP_CL_MSG: FuncDef = func!(
     /// Sends a message from client to server, may also send an ACK in response
     resynth fn client_message(
         =>
-        send_ack: ValDef::Bool(true),
-        seq: ValDef::Type(ValType::U32),
-        ack: ValDef::Type(ValType::U32),
-        frag_off: ValDef::U16(0),
+        send_ack: Bool = true,
+        seq: Type = ValType::U32,
+        ack: Type = ValType::U32,
+        frag_off: U16 = 0,
         =>
         Str
     ) -> PktGen
@@ -52,14 +52,14 @@ const TCP_CL_MSG: FuncDef = func_def!(
     }
 );
 
-const TCP_SV_MSG: FuncDef = func_def!(
+const TCP_SV_MSG: FuncDef = func!(
     /// Sends a message from server to client, may also send an ACK in response
     resynth fn server_message(
         =>
-        send_ack: ValDef::Bool(true),
-        seq: ValDef::Type(ValType::U32),
-        ack: ValDef::Type(ValType::U32),
-        frag_off: ValDef::U16(0),
+        send_ack: Bool = true,
+        seq: Type = ValType::U32,
+        ack: Type = ValType::U32,
+        frag_off: U16 = 0,
         =>
         Str
     ) -> PktGen
@@ -82,12 +82,12 @@ const TCP_SV_MSG: FuncDef = func_def!(
     }
 );
 
-const TCP_CL_SEG: FuncDef = func_def!(
+const TCP_CL_SEG: FuncDef = func!(
     /// Returns a single segment from client to server
     resynth fn client_segment(
         =>
-        seq: ValDef::Type(ValType::U32),
-        ack: ValDef::Type(ValType::U32),
+        seq: Type = ValType::U32,
+        ack: Type = ValType::U32,
         =>
         Str
     ) -> Pkt
@@ -108,12 +108,12 @@ const TCP_CL_SEG: FuncDef = func_def!(
     }
 );
 
-const TCP_SV_SEG: FuncDef = func_def!(
+const TCP_SV_SEG: FuncDef = func!(
     /// Returns a single segment from server to client
     resynth fn server_segment(
         =>
-        seq: ValDef::Type(ValType::U32),
-        ack: ValDef::Type(ValType::U32),
+        seq: Type = ValType::U32,
+        ack: Type = ValType::U32,
         =>
         Str
     ) -> Pkt
@@ -134,12 +134,12 @@ const TCP_SV_SEG: FuncDef = func_def!(
     }
 );
 
-const TCP_CL_RAW_SEG: FuncDef = func_def!(
+const TCP_CL_RAW_SEG: FuncDef = func!(
     /// Returns a single segment, minus the IP header, from client to server
     resynth fn client_raw_segment(
         =>
-        seq: ValDef::Type(ValType::U32),
-        ack: ValDef::Type(ValType::U32),
+        seq: Type = ValType::U32,
+        ack: Type = ValType::U32,
         =>
         Str
     ) -> Str
@@ -160,12 +160,12 @@ const TCP_CL_RAW_SEG: FuncDef = func_def!(
     }
 );
 
-const TCP_SV_RAW_SEG: FuncDef = func_def!(
+const TCP_SV_RAW_SEG: FuncDef = func!(
     /// Returns a single segment, minus the IP header, from server to client
     resynth fn server_raw_segment(
         =>
-        seq: ValDef::Type(ValType::U32),
-        ack: ValDef::Type(ValType::U32),
+        seq: Type = ValType::U32,
+        ack: Type = ValType::U32,
         =>
         Str
     ) -> Str
@@ -186,11 +186,11 @@ const TCP_SV_RAW_SEG: FuncDef = func_def!(
     }
 );
 
-const TCP_CL_HDR: FuncDef = func_def!(
+const TCP_CL_HDR: FuncDef = func!(
     /// Returns only the TCP header, from client to server
     resynth fn client_hdr(
         =>
-        bytes: ValDef::U32(0),
+        bytes: U32 = 0,
         =>
         Void
     ) -> Str
@@ -204,11 +204,11 @@ const TCP_CL_HDR: FuncDef = func_def!(
     }
 );
 
-const TCP_SV_HDR: FuncDef = func_def!(
+const TCP_SV_HDR: FuncDef = func!(
     /// Returns only the TCP header, from server to client
     resynth fn server_hdr(
         =>
-        bytes: ValDef::U32(0),
+        bytes: U32 = 0,
         =>
         Void
     ) -> Str
@@ -222,12 +222,12 @@ const TCP_SV_HDR: FuncDef = func_def!(
     }
 );
 
-const TCP_CL_ACK: FuncDef = func_def!(
+const TCP_CL_ACK: FuncDef = func!(
     /// Sends an ACK from the client
     resynth fn client_ack(
         =>
-        seq: ValDef::Type(ValType::U32),
-        ack: ValDef::Type(ValType::U32),
+        seq: Type = ValType::U32,
+        ack: Type = ValType::U32,
         =>
         Void
     ) -> Pkt
@@ -246,12 +246,12 @@ const TCP_CL_ACK: FuncDef = func_def!(
     }
 );
 
-const TCP_SV_ACK: FuncDef = func_def!(
+const TCP_SV_ACK: FuncDef = func!(
     /// Sends an ACK from the server
     resynth fn server_ack(
         =>
-        seq: ValDef::Type(ValType::U32),
-        ack: ValDef::Type(ValType::U32),
+        seq: Type = ValType::U32,
+        ack: Type = ValType::U32,
         =>
         Void
     ) -> Pkt
@@ -270,7 +270,7 @@ const TCP_SV_ACK: FuncDef = func_def!(
     }
 );
 
-const TCP_CL_HOLE: FuncDef = func_def!(
+const TCP_CL_HOLE: FuncDef = func!(
     /// Creates a hole in the sever's Tx sequence space, making it look like we missed a packet
     /// from the client
     resynth fn client_hole(
@@ -290,7 +290,7 @@ const TCP_CL_HOLE: FuncDef = func_def!(
     }
 );
 
-const TCP_SV_HOLE: FuncDef = func_def!(
+const TCP_SV_HOLE: FuncDef = func!(
     /// Creates a hole in the sever's Tx sequence space, making it look like we missed a packet
     /// from the server
     resynth fn server_hole(
@@ -310,7 +310,7 @@ const TCP_SV_HOLE: FuncDef = func_def!(
     }
 );
 
-const TCP_CL_CLOSE: FuncDef = func_def!(
+const TCP_CL_CLOSE: FuncDef = func!(
     /// Shutdown both sides of the TCP connection, with the client sending the first FIN
     resynth fn client_close(
         =>
@@ -325,7 +325,7 @@ const TCP_CL_CLOSE: FuncDef = func_def!(
     }
 );
 
-const TCP_SV_CLOSE: FuncDef = func_def!(
+const TCP_SV_CLOSE: FuncDef = func!(
     /// Shutdown both sides of the TCP connection, with the server sending the first FIN
     resynth fn server_close(
         =>
@@ -340,7 +340,7 @@ const TCP_SV_CLOSE: FuncDef = func_def!(
     }
 );
 
-const TCP_CL_RESET: FuncDef = func_def!(
+const TCP_CL_RESET: FuncDef = func!(
     /// Send a RST packet from the client
     resynth fn client_reset(
         =>
@@ -355,7 +355,7 @@ const TCP_CL_RESET: FuncDef = func_def!(
     }
 );
 
-const TCP_SV_RESET: FuncDef = func_def!(
+const TCP_SV_RESET: FuncDef = func!(
     /// Send a RST packet from the server
     resynth fn server_reset(
         =>
@@ -399,15 +399,15 @@ impl Class for TcpFlow {
     }
 }
 
-const FLOW: FuncDef = func_def!(
+const FLOW: FuncDef = func!(
     /// Create a TCP flow context, from which packets can be created
     resynth fn flow(
         cl: Sock4,
         sv: Sock4,
         =>
-        cl_seq: ValDef::U32(1),
-        sv_seq: ValDef::U32(1),
-        raw: ValDef::Bool(false),
+        cl_seq: U32 = 1,
+        sv_seq: U32 = 1,
+        raw: Bool = false,
         =>
         Void
     ) -> Obj

--- a/src/stdlib/ipv4/udp.rs
+++ b/src/stdlib/ipv4/udp.rs
@@ -3,20 +3,20 @@ use std::net::Ipv4Addr;
 use ezpkt::{UdpDgram, UdpFlow};
 use pkt::{ipv4::udp_hdr, AsBytes, Packet};
 
-use crate::func_def;
+use crate::func;
 use crate::libapi::{Class, ClassDef, FuncDef, Module};
 use crate::str::Buf;
 use crate::sym::Symbol;
 use crate::val::{Val, ValDef};
 
-const BROADCAST: FuncDef = func_def!(
+const BROADCAST: FuncDef = func!(
     /// Send a broadcast datagram
     resynth fn broadcast(
         src: Sock4,
         dst: Sock4,
         =>
-        srcip: ValDef::Type(ValType::Ip4),
-        raw: ValDef::Bool(false),
+        srcip: Type = ValType::Ip4,
+        raw: Bool = false,
         =>
         Str
     ) -> Pkt
@@ -42,13 +42,13 @@ const BROADCAST: FuncDef = func_def!(
     }
 );
 
-const UNICAST: FuncDef = func_def!(
+const UNICAST: FuncDef = func!(
     /// Send a unicast datagram
     resynth fn unicast(
         src: Sock4,
         dst: Sock4,
         =>
-        raw: ValDef::Bool(false),
+        raw: Bool = false,
         =>
         Str
     ) -> Pkt
@@ -66,14 +66,14 @@ const UNICAST: FuncDef = func_def!(
     }
 );
 
-const HDR: FuncDef = func_def!(
+const HDR: FuncDef = func!(
     /// Returns a UDP header (with no IP header)
     resynth fn hdr(
         src: U16,
         dst: U16,
         =>
-        len: ValDef::U16(0),
-        csum: ValDef::U16(0),
+        len: U16 = 0,
+        csum: U16 = 0,
         =>
         Void
     ) -> Str
@@ -94,12 +94,12 @@ const HDR: FuncDef = func_def!(
     }
 );
 
-const CL_DGRAM: FuncDef = func_def!(
+const CL_DGRAM: FuncDef = func!(
     /// Send a datagram from client to server
     resynth fn client_dgram(
         =>
-        frag_off: ValDef::U16(0),
-        csum: ValDef::Bool(true),
+        frag_off: U16 = 0,
+        csum: Bool = true,
         =>
         Str
     ) -> Pkt
@@ -122,12 +122,12 @@ const CL_DGRAM: FuncDef = func_def!(
     }
 );
 
-const SV_DGRAM: FuncDef = func_def!(
+const SV_DGRAM: FuncDef = func!(
     /// Send a datagram from server to client
     resynth fn server_dgram(
         =>
-        frag_off: ValDef::U16(0),
-        csum: ValDef::Bool(true),
+        frag_off: U16 = 0,
+        csum: Bool = true,
         =>
         Str
     ) -> Pkt
@@ -150,11 +150,11 @@ const SV_DGRAM: FuncDef = func_def!(
     }
 );
 
-const CL_RAW_DGRAM: FuncDef = func_def!(
+const CL_RAW_DGRAM: FuncDef = func!(
     /// Return a datagram from client to server (minus IP header)
     resynth fn client_raw_dgram(
         =>
-        csum: ValDef::Bool(true),
+        csum: Bool = true,
         =>
         Str
     ) -> Str
@@ -176,11 +176,11 @@ const CL_RAW_DGRAM: FuncDef = func_def!(
     }
 );
 
-const SV_RAW_DGRAM: FuncDef = func_def!(
+const SV_RAW_DGRAM: FuncDef = func!(
     /// Return a datagram from server to client (minus IP header)
     resynth fn server_raw_dgram(
         =>
-        csum: ValDef::Bool(true),
+        csum: Bool = true,
         =>
         Str
     ) -> Str
@@ -218,13 +218,13 @@ impl Class for UdpFlow {
     }
 }
 
-const FLOW: FuncDef = func_def!(
+const FLOW: FuncDef = func!(
     /// Create a UDP flow context, from which other packets can be created
     resynth fn flow(
         cl: Sock4,
         sv: Sock4,
         =>
-        raw: ValDef::Bool(false),
+        raw: Bool = false,
         =>
         Void
     ) -> Obj

--- a/src/stdlib/netbios.rs
+++ b/src/stdlib/netbios.rs
@@ -2,7 +2,7 @@ use pkt::dns::{rcode, DnsFlags};
 use pkt::netbios::{name, ns};
 
 use crate::err::Error::RuntimeError;
-use crate::func_def;
+use crate::func;
 use crate::libapi::{FuncDef, Module};
 use crate::str::Buf;
 use crate::sym::Symbol;
@@ -38,20 +38,20 @@ const RCODE: Module = module! {
     }
 };
 
-const NBNS_FLAGS: FuncDef = func_def!(
+const NBNS_FLAGS: FuncDef = func!(
     /// Returns netbios-ns flags
     resynth fn flags(
         opcode: U8,
         =>
-        response: ValDef::Bool(false),
-        aa: ValDef::Bool(false),
-        tc: ValDef::Bool(false),
-        rd: ValDef::Bool(false),
-        ra: ValDef::Bool(false),
-        z: ValDef::Bool(false),
-        ad: ValDef::Bool(false), // must be zero
-        b: ValDef::Bool(false),
-        rcode: ValDef::U8(rcode::NOERROR),
+        response: Bool = false,
+        aa: Bool = false,
+        tc: Bool = false,
+        rd: Bool = false,
+        ra: Bool = false,
+        z: Bool = false,
+        ad: Bool = false, // must be zero
+        b: Bool = false,
+        rcode: U8 = rcode::NOERROR,
         =>
         Void
     ) -> U16
@@ -94,11 +94,11 @@ pub const NS: Module = module! {
     }
 };
 
-const NAME_ENCODE: FuncDef = func_def! (
+const NAME_ENCODE: FuncDef = func! (
     /// Encode a netbios name, including the one-byte suffix field
     resynth fn encode(
         =>
-        suffix: ValDef::U8(0),
+        suffix: U8 = 0,
         =>
         Str
     ) -> Str

--- a/src/stdlib/std.rs
+++ b/src/stdlib/std.rs
@@ -1,10 +1,10 @@
-use crate::func_def;
+use crate::func;
 use crate::libapi::{FuncDef, Module};
 use crate::str::Buf;
 use crate::sym::Symbol;
 use crate::val::Val;
 
-const BE16: FuncDef = func_def!(
+const BE16: FuncDef = func!(
     /// Encode a 16bit integer into 2 big-endian bytes
     resynth fn be16(
         val: U64,
@@ -18,7 +18,7 @@ const BE16: FuncDef = func_def!(
     }
 );
 
-const BE32: FuncDef = func_def!(
+const BE32: FuncDef = func!(
     /// Encode a 32bit integer into 4 big-endian bytes
     resynth fn be32(
         val: U64,
@@ -32,7 +32,7 @@ const BE32: FuncDef = func_def!(
     }
 );
 
-const BE64: FuncDef = func_def!(
+const BE64: FuncDef = func!(
     /// Encode a 64bit integer into 8 big-endian bytes
     resynth fn be64(
         val: U64,
@@ -46,7 +46,7 @@ const BE64: FuncDef = func_def!(
     }
 );
 
-const LE16: FuncDef = func_def!(
+const LE16: FuncDef = func!(
     /// Encode a 16bit integer into 2 little-endian bytes
     resynth fn le16(
         val: U64,
@@ -60,7 +60,7 @@ const LE16: FuncDef = func_def!(
     }
 );
 
-const LE32: FuncDef = func_def!(
+const LE32: FuncDef = func!(
     /// Encode a 32bit integer into 4 little-endian bytes
     resynth fn le32(
         val: U64,
@@ -74,7 +74,7 @@ const LE32: FuncDef = func_def!(
     }
 );
 
-const LE64: FuncDef = func_def!(
+const LE64: FuncDef = func!(
     /// Encode a 64bit integer into 8 little-endian bytes
     resynth fn le64(
         val: U64,
@@ -88,7 +88,7 @@ const LE64: FuncDef = func_def!(
     }
 );
 
-const U8: FuncDef = func_def!(
+const U8: FuncDef = func!(
     /// Convert an integer into a one-byte string
     resynth fn u8(
         val: U8,
@@ -102,7 +102,7 @@ const U8: FuncDef = func_def!(
     }
 );
 
-const LEN_BE64: FuncDef = func_def! (
+const LEN_BE64: FuncDef = func! (
     /// Prefix a buffer with a 64-bit big-endian length field
     resynth fn len_be64(
         =>
@@ -121,7 +121,7 @@ const LEN_BE64: FuncDef = func_def! (
     }
 );
 
-const LEN_BE32: FuncDef = func_def! (
+const LEN_BE32: FuncDef = func! (
     /// Prefix a buffer with a 32-bit big-endian length field
     resynth fn len_be32(
         =>
@@ -140,7 +140,7 @@ const LEN_BE32: FuncDef = func_def! (
     }
 );
 
-const LEN_BE16: FuncDef = func_def! (
+const LEN_BE16: FuncDef = func! (
     /// Prefix a buffer with a 16-bit big-endian length field
     resynth fn len_be16(
         =>
@@ -159,7 +159,7 @@ const LEN_BE16: FuncDef = func_def! (
     }
 );
 
-const LEN_U8: FuncDef = func_def! (
+const LEN_U8: FuncDef = func! (
     /// Prefix a buffer with a 8-bit byte length field
     resynth fn len_u8(
         =>

--- a/src/stdlib/text.rs
+++ b/src/stdlib/text.rs
@@ -1,10 +1,10 @@
-use crate::func_def;
+use crate::func;
 use crate::libapi::{FuncDef, Module};
 use crate::str::Buf;
 use crate::sym::Symbol;
 use crate::val::{Val, ValDef};
 
-const CONCAT: FuncDef = func_def!(
+const CONCAT: FuncDef = func!(
     /// Concatenate strings
     resynth fn concat(
         =>
@@ -16,7 +16,7 @@ const CONCAT: FuncDef = func_def!(
     }
 );
 
-const CRLFLINES: FuncDef = func_def!(
+const CRLFLINES: FuncDef = func!(
     /// join strings with CRLF line-endings
     resynth fn crlflines(
         =>
@@ -28,7 +28,7 @@ const CRLFLINES: FuncDef = func_def!(
     }
 );
 
-const LEN: FuncDef = func_def!(
+const LEN: FuncDef = func!(
     /// Return the length of a string (or strings)
     resynth fn len(
         =>

--- a/src/stdlib/time.rs
+++ b/src/stdlib/time.rs
@@ -1,4 +1,4 @@
-use crate::func_def;
+use crate::func;
 use crate::libapi::{FuncDef, Module};
 use crate::sym::Symbol;
 use crate::val::Val;
@@ -7,7 +7,7 @@ const HZ: u64 = 1_000_000_000;
 const KHZ: u64 = HZ / 1000;
 const MHZ: u64 = KHZ / 1000;
 
-const JUMP_SECS: FuncDef = func_def!(
+const JUMP_SECS: FuncDef = func!(
     /// Advance the pcap timestamp clock by some number of seconds
     resynth fn jump_seconds(
         seconds: U32,
@@ -22,7 +22,7 @@ const JUMP_SECS: FuncDef = func_def!(
     }
 );
 
-const JUMP_MILLIS: FuncDef = func_def!(
+const JUMP_MILLIS: FuncDef = func!(
     /// Advance the pcap timestamp clock by some number of milliseconds
     resynth fn jump_millis(
         ms: U64,
@@ -37,7 +37,7 @@ const JUMP_MILLIS: FuncDef = func_def!(
     }
 );
 
-const JUMP_MICROS: FuncDef = func_def!(
+const JUMP_MICROS: FuncDef = func!(
     /// Advance the pcap timestamp clock by some number of microseconds
     resynth fn jump_micros(
         us: U64,
@@ -52,7 +52,7 @@ const JUMP_MICROS: FuncDef = func_def!(
     }
 );
 
-const JUMP_NANOS: FuncDef = func_def!(
+const JUMP_NANOS: FuncDef = func!(
     /// Advance the pcap timestamp clock by some number of nanoseconds
     resynth fn jump_nanos(
         ns: U64,

--- a/src/stdlib/tls.rs
+++ b/src/stdlib/tls.rs
@@ -4,7 +4,7 @@ use crate::libapi::{FuncDef, Module};
 use crate::str::Buf;
 use crate::sym::Symbol;
 use crate::val::{Val, ValDef};
-use crate::{func_def, module};
+use crate::{func, module};
 
 const VERSION: Module = module!(
     /// TLS Versions
@@ -837,12 +837,12 @@ const CIPHER: Module = module! {
     }
 };
 
-const TLS_MESSAGE: FuncDef = func_def! (
+const TLS_MESSAGE: FuncDef = func! (
     /// Returns a TLS record
     resynth fn message(
         =>
-        version: ValDef::U16(version::TLS_1_2),
-        content: ValDef::U8(content::HANDSHAKE),
+        version: U16 = version::TLS_1_2,
+        content: U8 = content::HANDSHAKE,
         =>
         Str
     ) -> Str
@@ -863,7 +863,7 @@ const TLS_MESSAGE: FuncDef = func_def! (
     }
 );
 
-const TLS_EXTENSION: FuncDef = func_def! (
+const TLS_EXTENSION: FuncDef = func! (
     /// Returns a TLS extension
     resynth fn extension(
         ext: U16,
@@ -890,7 +890,7 @@ fn len24(len: usize) -> [u8; 3] {
     [b[1], b[2], b[3]]
 }
 
-const TLS_CIPHERS: FuncDef = func_def! (
+const TLS_CIPHERS: FuncDef = func! (
     /// Returns a TLS ciphers list
     resynth fn ciphers(
         =>
@@ -913,14 +913,14 @@ const TLS_CIPHERS: FuncDef = func_def! (
     }
 );
 
-const TLS_CLIENT_HELLO: FuncDef = func_def! (
+const TLS_CLIENT_HELLO: FuncDef = func! (
     /// Returns a TLS client hello
     resynth fn client_hello(
         =>
-        version: ValDef::U16(version::TLS_1_2),
-        sessionid: ValDef::Str(b"\x00"),
-        ciphers: ValDef::Str(b"\x00\x02\x00\x00"), // null cipher
-        compression: ValDef::Str(b"\x01\x00"), // null compression
+        version: U16 = version::TLS_1_2,
+        sessionid: Str = b"\x00",
+        ciphers: Str = b"\x00\x02\x00\x00", // null cipher
+        compression: Str = b"\x01\x00", // null compression
         =>
         Str
     ) -> Str
@@ -961,14 +961,14 @@ const TLS_CLIENT_HELLO: FuncDef = func_def! (
     }
 );
 
-const TLS_SERVER_HELLO: FuncDef = func_def! (
+const TLS_SERVER_HELLO: FuncDef = func! (
     /// Returns a TLS server hello
     resynth fn server_hello(
         =>
-        version: ValDef::U16(version::TLS_1_2),
-        sessionid: ValDef::Str(b"\x00"),
-        cipher: ValDef::U16(ciphers::NULL_WITH_NULL_NULL),
-        compression: ValDef::U8(0),
+        version: U16 = version::TLS_1_2,
+        sessionid: Str = b"\x00",
+        cipher: U16 = ciphers::NULL_WITH_NULL_NULL,
+        compression: U8 = 0,
         =>
         Str
     ) -> Str
@@ -1010,7 +1010,7 @@ const TLS_SERVER_HELLO: FuncDef = func_def! (
     }
 );
 
-const TLS_SNI: FuncDef = func_def! (
+const TLS_SNI: FuncDef = func! (
     /// Returns a TLS SNI extension
     resynth fn sni(
         =>
@@ -1039,7 +1039,7 @@ const TLS_SNI: FuncDef = func_def! (
     }
 );
 
-const TLS_CERTIFICATES: FuncDef = func_def! (
+const TLS_CERTIFICATES: FuncDef = func! (
     /// Returns a chain of X.509 certificates
     resynth fn certificates(
         =>

--- a/src/stdlib/vxlan.rs
+++ b/src/stdlib/vxlan.rs
@@ -2,13 +2,13 @@ use std::rc::Rc;
 
 use pkt::{vxlan, Packet};
 
-use crate::func_def;
+use crate::func;
 use crate::libapi::{Class, ClassDef, FuncDef, Module};
 use crate::sym::Symbol;
 use crate::val::{Val, ValDef};
 use ezpkt::VxlanFlow;
 
-const ENCAP: FuncDef = func_def!(
+const ENCAP: FuncDef = func!(
     /// Encapsulate a series of packets
     resynth fn encap(
         gen: PktGen
@@ -32,7 +32,7 @@ const ENCAP: FuncDef = func_def!(
     }
 );
 
-const DGRAM: FuncDef = func_def!(
+const DGRAM: FuncDef = func!(
     /// Encapsulate a single packet
     resynth fn dgram(
         pkt: Pkt
@@ -64,14 +64,14 @@ impl Class for VxlanFlow {
     }
 }
 
-const SESSION: FuncDef = func_def!(
+const SESSION: FuncDef = func!(
     /// Create a VXLAN session
     resynth fn session(
         cl: Sock4,
         sv: Sock4,
         =>
-        sessionid: ValDef::U32(0), // TODO: Make it optional
-        raw: ValDef::Bool(false),
+        sessionid: U32 = 0, // TODO: Make it optional
+        raw: Bool = false,
         =>
         Void
     ) -> Obj

--- a/src/test/args.rs
+++ b/src/test/args.rs
@@ -4,15 +4,15 @@ use crate::libapi::FuncDef;
 use crate::str::Buf;
 use crate::val::{Val, ValDef};
 
-const PLAIN: FuncDef = func_def! {
+const PLAIN: FuncDef = func! {
     /// PLAIN
     resynth fn PLAIN(
         a: U64,
         b: Str,
         =>
-        c: ValDef::U64(123),
-        d: ValDef::Str(b"hello"),
-        e: ValDef::Type(ValType::Bool),
+        c: U64 = 123,
+        d: Str = b"hello",
+        e: Type = ValType::Bool,
         =>
         Void
     ) -> Void
@@ -181,12 +181,12 @@ fn argvec_multiple_named_optional() {
     assert_eq!(Err(Error::TypeError), PLAIN.argvec(None, args),)
 }
 
-const COLLECT: FuncDef = func_def! {
+const COLLECT: FuncDef = func! {
     /// COLLECT
     resynth fn COLLECT(
         a: U64,
         =>
-        b: ValDef::U64(123),
+        b: U64 = 123,
         =>
         Str
     ) -> Void
@@ -254,7 +254,7 @@ fn collect_bad_type() {
     assert_eq!(Err(Error::TypeError), COLLECT.argvec(None, args),)
 }
 
-const EMPTY: FuncDef = func_def! {
+const EMPTY: FuncDef = func! {
     /// EMPTY
     resynth fn EMPTY(
         =>
@@ -292,13 +292,13 @@ fn argvec_empty_extra() {
     )
 }
 
-const NAMED: FuncDef = func_def! {
+const NAMED: FuncDef = func! {
     /// NAMED
     resynth fn NAMED(
         =>
-        a: ValDef::U64(123),
-        b: ValDef::Str(b"hello"),
-        c: ValDef::Bool(true),
+        a: U64 = 123,
+        b: Str = b"hello",
+        c: Bool = true,
         =>
         Void
     ) -> Void
@@ -322,13 +322,13 @@ fn argvec_optional_anonymous() {
     )
 }
 
-const OPTIONAL_COLLECT_STR: FuncDef = func_def! {
+const OPTIONAL_COLLECT_STR: FuncDef = func! {
     /// OPTIONAL_COLLECT_STR
     resynth fn OPTIONAL_COLLECT_STR(
         =>
-        a: ValDef::Bool(true),
-        b: ValDef::U64(123),
-        c: ValDef::Str(b"hello"),
+        a: Bool = true,
+        b: U64 = 123,
+        c: Str = b"hello",
         =>
         Str
     ) -> Void
@@ -353,13 +353,13 @@ fn argvec_optional_collect_str() {
     )
 }
 
-const OPTIONAL_COLLECT_U64: FuncDef = func_def! {
+const OPTIONAL_COLLECT_U64: FuncDef = func! {
     /// OPTIONAL_COLLECT_U64
     resynth fn OPTIONAL_COLLECT_U64(
         =>
-        a: ValDef::U64(123),
-        b: ValDef::Str(b"hello"),
-        c: ValDef::Bool(true),
+        a: U64 = 123,
+        b: Str = b"hello",
+        c: Bool = true,
         =>
         U64
     ) -> Void


### PR DESCRIPTION
Example of new function definition:

```resynth
const DNS_HOST: FuncDef = func!(
    /// Perform a DNS lookup, with response
    resynth fn host(
        client: Ip4,
        qname: Str,
        =>
        ttl: U32 = 229,
        ns: Ip4 = Ipv4Addr::new(1, 1, 1, 1),
        raw: Bool = false,
        =>
        Ip4
    ) -> PktGen
    |mut args| {
        let client: Ipv4Addr = args.next().into();
        let qname: DnsName = DnsName::from(args.next().as_ref());
        let ttl: u32 = args.next().into();
        let ns: Ipv4Addr = args.next().into();
        let raw: bool = args.next().into();
```