### PR TITLE
Basic support for VLAN

### DIFF
--- a/docs/eth/README.md
+++ b/docs/eth/README.md
@@ -6,8 +6,47 @@
 
 - [ethertype](ethertype/README.md)
 
+### Functions
+
+- [frame](#frame)
+- [from_ip](#from_ip)
+
 ### Constants
 
 | Name | Value |
 | ---- | ----- |
 | BROADCAST | `(bytes)"\xff\xff\xff\xff\xff\xff"` |
+
+
+
+## frame
+```resynth
+resynth fn frame (
+    src: bytes,
+    dst: bytes,
+    ethertype: u16 = 0x0800,
+    =>
+    *collect_args: bytes,
+) -> Pkt;
+```
+ Ethernet Frame
+
+ ### Arguments
+ * `dst` Destination ethernet address as bytes
+ * `src` Source ethernet address as bytes
+ * `ethertype` [Ethertype](ethertype/README.md), defaults to IPV4
+ * `*payload: Str` the payload bytes
+
+## from_ip
+```resynth
+resynth fn from_ip (
+    ip: Ip4,
+) -> bytes;
+```
+ Map IPv4 address into ethernet address
+
+ Right now you just get a locally administered IP address with the IP address as the last
+ four octets
+
+ ### Arguments
+ * `ip` Ip address

--- a/docs/ipv4/IpFrag.md
+++ b/docs/ipv4/IpFrag.md
@@ -13,17 +13,22 @@
 ## datagram
 ```resynth
 resynth fn datagram (
+    raw: bool = false,
     =>
     *collect_args: bytes,
 ) -> Pkt;
 ```
  Return the entire datagram without fragmenting it
 
+ ### Arguments
+ * 'raw' If true, then omit ethernet header
+
 ## fragment
 ```resynth
 resynth fn fragment (
     frag_off: u16,
     len: u16,
+    raw: bool = false,
     =>
     *collect_args: bytes,
 ) -> Pkt;
@@ -33,11 +38,13 @@ resynth fn fragment (
  ### Arguments
  * `frag_off` Offset in 8-byte blocks
  * `len` Length in bytes
+ * 'raw' If true, then omit ethernet header
 
 ## tail
 ```resynth
 resynth fn tail (
     frag_off: u16,
+    raw: bool = false,
     =>
     *collect_args: bytes,
 ) -> Pkt;
@@ -47,3 +54,4 @@ resynth fn tail (
 
  ### Arguments
  * `frag_off` Offset in 8-byte blocks
+ * 'raw' If true, then omit ethernet header

--- a/examples/frag-vlan.rsyn
+++ b/examples/frag-vlan.rsyn
@@ -1,0 +1,53 @@
+import text;
+import ipv4;
+import dns;
+import eth;
+import std;
+
+let client = 192.168.238.112;
+let server = 142.250.207.36;
+let google = 8.8.8.8;
+
+let dns = ipv4::udp::flow(
+  client/13749,
+  google/54,
+);
+
+let frag = ipv4::frag(
+  client,
+  google,
+  id: 0x2345,
+  proto: ipv4::proto::UDP,
+  dns.client_raw_dgram(
+    dns::hdr(
+      id: 0x1234,
+      flags: dns::flags(
+        opcode: dns::opcode::QUERY,
+        rd: 1,
+      ),
+      qdcount: 1,
+    ),
+    dns::question(
+      qname: dns::name("www", "google", "com"),
+      qtype: dns::qtype::A,
+      qclass: dns::class::IN,
+    )
+  )
+);
+
+eth::frame(
+  eth::from_ip(client),
+  eth::from_ip(google),
+  ethertype: eth::ethertype::VLAN,
+  std::be16(0),
+  std::be16(eth::ethertype::IPV4),
+  frag.fragment(0, 1, raw: true),
+);
+eth::frame(
+  eth::from_ip(client),
+  eth::from_ip(google),
+  ethertype: eth::ethertype::VLAN,
+  std::be16(0),
+  std::be16(eth::ethertype::IPV4),
+  frag.tail(1, raw: true),
+);

--- a/pkt/src/eth.rs
+++ b/pkt/src/eth.rs
@@ -21,6 +21,12 @@ pub struct eth_addr {
     octets: [u8; 6],
 }
 
+impl eth_addr {
+    pub fn new(octets: [u8; 6]) -> Self {
+        Self { octets }
+    }
+}
+
 impl Serialize for eth_addr {}
 
 impl From<Ipv4Addr> for eth_addr {
@@ -30,6 +36,12 @@ impl From<Ipv4Addr> for eth_addr {
         Self {
             octets: [0x00, 0x02, ip[0], ip[1], ip[2], ip[3]],
         }
+    }
+}
+
+impl<'a> AsRef<[u8]> for &'a eth_addr {
+    fn as_ref(&self) -> &'a [u8] {
+        &self.octets[..]
     }
 }
 

--- a/src/stdlib/eth.rs
+++ b/src/stdlib/eth.rs
@@ -1,8 +1,87 @@
-use pkt::eth::{ethertype, BROADCAST};
+use std::net::Ipv4Addr;
 
-use crate::libapi::Module;
+use pkt::eth::{eth_addr, eth_hdr, ethertype, BROADCAST};
+use pkt::Packet;
+
+use crate::err::Error;
+use crate::libapi::{FuncDef, Module};
+use crate::str::Buf;
 use crate::sym::Symbol;
-use crate::val::ValDef;
+use crate::val::{Val, ValDef};
+
+const FRAME_OVERHEAD: usize = std::mem::size_of::<eth_hdr>();
+
+fn ether<T: AsRef<[u8]>>(val: T) -> Result<eth_addr, Error> {
+    let val = val.as_ref();
+
+    if val.len() != 6 {
+        return Err(Error::RuntimeError);
+    }
+
+    let mut octets: [u8; 6] = [0; 6];
+    octets.copy_from_slice(&val[..6]);
+
+    Ok(eth_addr::new(octets))
+}
+
+const FRAME: FuncDef = func!(
+    /// Ethernet Frame
+    ///
+    /// ### Arguments
+    /// * `dst` Destination ethernet address as bytes
+    /// * `src` Source ethernet address as bytes
+    /// * `ethertype` [Ethertype](ethertype/README.md), defaults to IPV4
+    /// * `*payload: Str` the payload bytes
+    resynth fn frame(
+        src: Str,
+        dst: Str,
+        =>
+        ethertype: U16 = ethertype::IPV4,
+        =>
+        Str
+    ) -> Pkt
+    |mut args| {
+        let src: Buf = args.next().into();
+        let dst: Buf = args.next().into();
+        let ethertype: u16 = args.next().into();
+        let data: Buf = args.join_extra(b"").into();
+
+        let eth = eth_hdr::new(
+            ether(src)?,
+            ether(dst)?,
+            ethertype,
+        );
+
+        let pkt = Packet::with_capacity(FRAME_OVERHEAD + data.len());
+        pkt.push(eth);
+        pkt.push_bytes(data);
+
+        Ok(Val::from(pkt))
+    }
+);
+
+const FROM_IP: FuncDef = func!(
+    /// Map IPv4 address into ethernet address
+    ///
+    /// Right now you just get a locally administered IP address with the IP address as the last
+    /// four octets
+    ///
+    /// ### Arguments
+    /// * `ip` Ip address
+    resynth fn from_ip(
+        ip: Ip4,
+        =>
+        =>
+        Void
+    ) -> Str
+    |mut args| {
+        let ip: Ipv4Addr = args.next().into();
+
+        let eth = eth_addr::from(ip);
+
+        Ok(Val::Str(Buf::from_slice(&eth)))
+    }
+);
 
 const TYPE: Module = module! {
     /// # Ethernet Ethertypes
@@ -24,6 +103,8 @@ pub const MODULE: Module = module! {
     /// # Ethernet
     resynth mod eth {
         ethertype => Symbol::Module(&TYPE),
+        frame => Symbol::Func(&FRAME),
+        from_ip => Symbol::Func(&FROM_IP),
         BROADCAST => Symbol::Val(ValDef::Str(&BROADCAST)),
     }
 };

--- a/src/stdlib/ipv4/mod.rs
+++ b/src/stdlib/ipv4/mod.rs
@@ -99,10 +99,12 @@ const FRAG_FRAGMENT: FuncDef = func!(
     /// ### Arguments
     /// * `frag_off` Offset in 8-byte blocks
     /// * `len` Length in bytes
+    /// * 'raw' If true, then omit ethernet header
     resynth fn fragment(
         frag_off: U16,
         len: U16,
         =>
+        raw: Bool = false,
         =>
         Str
     ) -> Pkt
@@ -113,8 +115,9 @@ const FRAG_FRAGMENT: FuncDef = func!(
 
         let frag_off: u16 = args.next().into();
         let len: u16 = args.next().into();
+        let raw: bool = args.next().into();
 
-        Ok(this.fragment(frag_off, len).into())
+        Ok(this.fragment(frag_off, len, raw).into())
     }
 );
 
@@ -124,9 +127,11 @@ const FRAG_TAIL: FuncDef = func!(
     ///
     /// ### Arguments
     /// * `frag_off` Offset in 8-byte blocks
+    /// * 'raw' If true, then omit ethernet header
     resynth fn tail(
         frag_off: U16,
         =>
+        raw: Bool = false,
         =>
         Str
     ) -> Pkt
@@ -136,15 +141,20 @@ const FRAG_TAIL: FuncDef = func!(
         let this: &mut IpFrag = r.as_mut_any().downcast_mut().unwrap();
 
         let frag_off: u16 = args.next().into();
+        let raw: bool = args.next().into();
 
-        Ok(this.tail(frag_off).into())
+        Ok(this.tail(frag_off, raw).into())
     }
 );
 
 const FRAG_DATAGRAM: FuncDef = func!(
     /// Return the entire datagram without fragmenting it
+    ///
+    /// ### Arguments
+    /// * 'raw' If true, then omit ethernet header
     resynth fn datagram(
         =>
+        raw: Bool = false,
         =>
         Str
     ) -> Pkt
@@ -152,8 +162,9 @@ const FRAG_DATAGRAM: FuncDef = func!(
         let obj = args.take_this();
         let mut r = obj.borrow_mut();
         let this: &mut IpFrag = r.as_mut_any().downcast_mut().unwrap();
+        let raw: bool = args.next().into();
 
-        Ok(this.datagram().into())
+        Ok(this.datagram(raw).into())
     }
 );
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -9,6 +9,13 @@ pub struct Buf {
 
 impl Buf {
     #[inline]
+    pub fn from_slice<T: AsRef<[u8]>>(s: T) -> Self {
+        Self {
+            inner: Rc::new(s.as_ref().to_owned()),
+        }
+    }
+
+    #[inline]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
@@ -42,7 +49,7 @@ impl From<Vec<u8>> for Buf {
     }
 }
 
-// Must take reference here because otherwise trait can be implented for self
+// Must take reference here because otherwise trait can be implemented for self
 impl<T> From<&T> for Buf
 where
     T: AsRef<[u8]> + ?Sized,

--- a/src/val.rs
+++ b/src/val.rs
@@ -92,7 +92,13 @@ pub trait Typed {
     fn is_string_coercible(&self) -> bool {
         matches!(
             self.val_type(),
-            ValType::Str | ValType::U8 | ValType::U16 | ValType::U32 | ValType::U64 | ValType::Ip4
+            ValType::Pkt
+                | ValType::Str
+                | ValType::U8
+                | ValType::U16
+                | ValType::U32
+                | ValType::U64
+                | ValType::Ip4
         )
     }
 
@@ -400,6 +406,7 @@ impl From<Val> for Buf {
     fn from(v: Val) -> Self {
         /* Must be implemented for all types which are Typed::is_string_coercible() */
         match v {
+            Val::Pkt(s) => Buf::from(s.to_vec()),
             Val::Str(s) => s,
             Val::U8(u) => Buf::from(&u.to_be_bytes()),
             Val::U16(u) => Buf::from(&u.to_be_bytes()),


### PR DESCRIPTION
Right now it's difficult, if not impossible to generate VLAN packets.

We solve this by adding several building blocks:
1. Add `eth::frame()` function which allows you to construct arbitrary ethernet frames
2. Most IPv4 functions allow for a `raw` boolean parameter which allows packets to be generated without an ethernet header, the one exception was IP fragment generation. This capability allows for generated IP packets to be combined with the above-mentioned `eth::frame()` function, in this way, a VLAN header can be inserted as bytes between the ethernet header and the IP packet.
3. Allow packets to be coerced into byte strings in function arguments, this allows generated `Pkt` type variables to be used as parameter to `eth::frame()`

Finally, add an example which demonstrates all of the above working together.

There is more work to be done in this area, specifically we should add functions for generating VLAN headers, and it would be nice to find a way to control how network layer protocols get encapsulated in ethernet so that we can build complex flows using VLAN or cisco fabricpath or whatever else at the physical layer.