### PR TITLE
Use std::io::IsTerminal instead of atty crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ regex = "1.12.3"
 concat-with = "0.2.9"
 
 # For cli
-atty = { version = "0.2.14", optional = true}
 termcolor = {version = "1.4", optional = true}
 clap = {version = "4.6", optional = true, features = ["cargo", "derive"]}
 bytemuck = { version = "1.25.0", features = ["derive"] }
@@ -67,4 +66,4 @@ required-features = ["cli"]
 default = [
   "cli",
 ]
-cli = ["clap", "atty", "termcolor"]
+cli = ["clap", "termcolor"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ use resynth::{EOF, Error, Lexer, Loc, Parser, Program};
 use resynth::{error, ok, warn};
 
 use std::borrow::Cow;
-use std::io::BufRead;
+use std::io::{BufRead, IsTerminal};
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
@@ -151,7 +151,7 @@ fn resynth() -> Result<(), ()> {
         "always" => ColorChoice::Always,
         "ansi" => ColorChoice::AlwaysAnsi,
         "auto" => {
-            if atty::is(atty::Stream::Stdout) {
+            if std::io::stdout().is_terminal() {
                 ColorChoice::Auto
             } else {
                 ColorChoice::Never


### PR DESCRIPTION
This crate is deprecated and no longer provided by Fedora 44.